### PR TITLE
populate __init__.py with package docstring and __version__

### DIFF
--- a/src/rda_python_dsarch/__init__.py
+++ b/src/rda_python_dsarch/__init__.py
@@ -1,1 +1,29 @@
+"""rda_python_dsarch: dataset archive (dsarch) utility package.
 
+This package exposes two parallel APIs:
+
+1. Legacy module-based API (back-compat). Import the capitalized
+   submodules and call their module-level functions, e.g.::
+
+       from rda_python_dsarch import PgArch, PgMeta
+
+2. Class-based API (preferred for new code). Import the class from the
+   lower-case module and either instantiate or subclass it, e.g.::
+
+       from rda_python_dsarch.pg_arch import PgArch
+       from rda_python_dsarch.pg_meta import PgMeta
+
+The legacy submodules are eagerly imported below so that
+``from rda_python_dsarch import PgArch`` continues to return the module
+object that existing callers expect.
+"""
+
+from . import PgArch, PgMeta
+
+__version__ = "2.0.20"
+
+__all__ = [
+   "PgArch",
+   "PgMeta",
+   "__version__",
+]


### PR DESCRIPTION
Eagerly imports the legacy capitalized submodules so that ``from <package> import Pg<Name>`` continues to return the module object that existing callers depend on. Documents both the legacy module-based API and the preferred class-based API.